### PR TITLE
Fix readme - babel node not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 npm install
 
-npm install -g babel-node
+npm install -g babel-cli
 
 babel-node index
 


### PR DESCRIPTION
Don't exists ```babel-node``` package, ```babel-node``` cli is into ```babel-cli``` package.